### PR TITLE
Push and reload models from Hugging Face

### DIFF
--- a/models_mae.py
+++ b/models_mae.py
@@ -18,6 +18,9 @@ from mae_st.util import video_vit
 from mae_st.util.logging import master_print as print
 
 
+from huggingface_hub import PyTorchModelHubMixin
+
+
 class MaskedAutoencoderViT(nn.Module):
     """Masked Autoencoder with VisionTransformer backbone"""
 
@@ -472,3 +475,45 @@ def mae_vit_huge_patch14(**kwargs):
         **kwargs,
     )
     return model
+
+
+class MAE(MaskedAutoencoderViT, PyTorchModelHubMixin):
+    def __init__(self, img_size=224,
+                        patch_size=16,
+                        in_chans=3,
+                        embed_dim=1024,
+                        depth=24,
+                        num_heads=16,
+                        decoder_embed_dim=512,
+                        decoder_depth=8,
+                        decoder_num_heads=16,
+                        mlp_ratio=4.0,
+                        norm_pix_loss=False,
+                        num_frames=16,
+                        t_patch_size=4,
+                        no_qkv_bias=False,
+                        sep_pos_embed=False,
+                        trunc_init=False,
+                        cls_embed=False,
+                        pred_t_dim=8,
+    ):
+        super().__init__(img_size=img_size,
+                            patch_size=patch_size,
+                            in_chans=in_chans,
+                            embed_dim=embed_dim,
+                            depth=depth,
+                            num_heads=num_heads,
+                            decoder_embed_dim=decoder_embed_dim,
+                            decoder_depth=decoder_depth,
+                            decoder_num_heads=decoder_num_heads,
+                            mlp_ratio=mlp_ratio,
+                            norm_pix_loss=norm_pix_loss,
+                            num_frames=num_frames,
+                            t_patch_size=t_patch_size,
+                            no_qkv_bias=no_qkv_bias,
+                            sep_pos_embed=sep_pos_embed,
+                            trunc_init=trunc_init,
+                            cls_embed=cls_embed,
+                            pred_t_dim=pred_t_dim,
+                            norm_layer=partial(nn.LayerNorm, eps=1e-6), 
+                            patch_embed=video_vit.PatchEmbed)

--- a/models_mae.py
+++ b/models_mae.py
@@ -517,3 +517,16 @@ class MAE(MaskedAutoencoderViT, PyTorchModelHubMixin):
                             pred_t_dim=pred_t_dim,
                             norm_layer=partial(nn.LayerNorm, eps=1e-6), 
                             patch_embed=video_vit.PatchEmbed)
+        
+# define model
+model = MAE(patch_size=16,
+            embed_dim=768,
+            depth=12,
+            num_heads=12,
+            mlp_ratio=4)
+
+# push to hub
+model.push_to_hub("facebook/mae_vit_base_patch16")
+
+# reload
+model = MAE.from_pretrained("facebook/mae_vit_base_patch16")


### PR DESCRIPTION
Similar to [#26](https://github.com/facebookresearch/hiera/pull/26), this showcases the use of the `PyTorchModelHubMixin` class, which allows to add from_pretrained and push_to_hub capabilities to any nn.Module.

Hence this could improve the discoverability of the MAE-st models, by adding model cards, tags, etc. so that people can easily find them on the 🤗 hub.

Usage is as follows:

```python
from models_mae import MAE

model = MAE.from_pretrained("facebook/mae_vit_base_patch16")
```

cc @amyreese it would be really great if Meta starts to adopt leveraging the `mixin` class for pushing and reloading custom nn.Module classes from the hub, rather than Github/internal hosting, to improve discoverability and it also comes with download metrics, meaning that you can see how many times people download and use your models.

Docs is here: https://huggingface.co/docs/hub/models-uploading#upload-a-pytorch-model-using-huggingfacehub